### PR TITLE
feat: add synthwave menu and UI redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The game now uses modern JavaScript modules and [anime.js](https://animejs.com/)
 
 ## Features
 
-- Retro start menu with aggressive synthwave vibes
-- 8‑bit inspired UI in pink and black tones
+- 8‑bit start menu with subtle wormhole animation and star field
+- Modern dark interface accented with cyan highlights
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Jeanmichelgame.html is an aim-training style browser game. Follow Jean-Michel wi
 
 The game now uses modern JavaScript modules and [anime.js](https://animejs.com/) for animations.
 
+## Features
+
+- Retro start menu with aggressive synthwave vibes
+- 8‑bit inspired UI in pink and black tones
+
 ## Demo
 
 Coming soon

--- a/jeanmichelgame.html
+++ b/jeanmichelgame.html
@@ -13,13 +13,13 @@
   <body>
     <div id="menu" class="menu-screen">
       <h1 class="title">Jeanmichel Game</h1>
-      <button id="startButton" class="btn-synth">Start</button>
+      <button id="startButton" class="btn">Jouer</button>
     </div>
 
     <div id="gameUI" class="game-ui hidden">
       <div class="top-bar">
         <div class="score">Score: <span id="top">0</span></div>
-        <button id="resetButton" class="btn-synth small">Reset</button>
+        <button id="resetButton" class="btn small">Reset</button>
       </div>
 
       <div class="play-area">

--- a/jeanmichelgame.html
+++ b/jeanmichelgame.html
@@ -3,21 +3,28 @@
   <head>
     <meta charset="utf-8" />
     <title>Jeanmichel Game</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-    <link rel="stylesheet" href="public/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="public/style.css" />
     <script src="public/libs/anime.min.js"></script>
     <script type="module" src="src/main.js"></script>
   </head>
   <body>
-    <div id="startButton" class="bouton1 btn btn-danger">Go</div>
-    <div id="resetButton" class="bouton1 btn btn-danger">Reset</div>
-
-    <div class="score">
-      <p>Score : <span id="top">0</span></p>
+    <div id="menu" class="menu-screen">
+      <h1 class="title">Jeanmichel Game</h1>
+      <button id="startButton" class="btn-synth">Start</button>
     </div>
 
-    <div>
-      <img id="jeanmichel" src="public/img/lafleurguy.png" width="100" height="190" draggable="false" />
+    <div id="gameUI" class="game-ui hidden">
+      <div class="top-bar">
+        <div class="score">Score: <span id="top">0</span></div>
+        <button id="resetButton" class="btn-synth small">Reset</button>
+      </div>
+
+      <div class="play-area">
+        <img id="jeanmichel" src="public/img/lafleurguy.png" width="100" height="190" draggable="false" />
+      </div>
     </div>
   </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,40 +1,83 @@
 body {
-        padding-top: 15px;
-        padding-left: 15px;
-        font-size: 37px;
-        color:white;
-        overflow: hidden;
-        background-color: black;
-        background-image:url(img/synthback5.png);
-        background-repeat: no-repeat;
-        background-size: 100%;
-        background-attachment: fixed;
-        background-position: bottom;
+  margin: 0;
+  font-family: 'Press Start 2P', cursive;
+  color: #ff2d90;
+  background: radial-gradient(circle at top, #ff2d90 0%, #000 70%);
+  overflow: hidden;
 }
 
-.bouton1 {
-        background-color: #046ca3;
-        padding: 10px 12px;
-        text-align: center;
-        display: inline-block;
-        font-size: 25px;
-        margin: 11px 2px;
-        cursor: pointer;
+.hidden {
+  display: none;
+}
+
+.menu-screen {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: radial-gradient(circle at center, #ff2d90 0%, #000 70%);
+  text-align: center;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+}
+
+.btn-synth {
+  background: #000;
+  color: #ff2d90;
+  border: 4px solid #ff2d90;
+  padding: 20px 30px;
+  cursor: pointer;
+  text-transform: uppercase;
+  box-shadow: 4px 4px #ff2d90;
+}
+
+.btn-synth.small {
+  padding: 10px 15px;
+  font-size: 0.8rem;
+  box-shadow: 3px 3px #ff2d90;
+}
+
+.btn-synth:active {
+  box-shadow: none;
+  transform: translate(4px, 4px);
+}
+
+.game-ui {
+  height: 100vh;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  height: 80px;
 }
 
 .score {
-        position: absolute;
-        margin-left: 10px;
-        display: inline-block;
+  font-size: 1rem;
 }
 
 #top {
-        font-size: 50px;
-        color: #046ca3;
+  font-size: 1.5rem;
+  color: #ff2d90;
+}
+
+.play-area {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 80px);
 }
 
 #jeanmichel {
-        cursor: crosshair;
-        position: absolute;
-        top: 500px;
+  cursor: crosshair;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  image-rendering: pixelated;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,23 +1,75 @@
 body {
   margin: 0;
   font-family: 'Press Start 2P', cursive;
-  color: #ff2d90;
-  background: radial-gradient(circle at top, #ff2d90 0%, #000 70%);
+  color: #fff;
+  background: #000;
   overflow: hidden;
 }
 
-.hidden {
-  display: none;
-}
-
 .menu-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background: radial-gradient(circle at center, #ff2d90 0%, #000 70%);
   text-align: center;
+  overflow: hidden;
+  background: #000;
+}
+
+.menu-screen::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: repeating-conic-gradient(
+    from 0deg,
+    rgba(0, 255, 255, 0.1) 0deg 10deg,
+    rgba(0, 0, 0, 0) 10deg 20deg
+  );
+  animation: spin 20s linear infinite;
+  z-index: -2;
+}
+
+.menu-screen::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: radial-gradient(#fff 1px, transparent 1px),
+    radial-gradient(#fff 1px, transparent 1px);
+  background-size: 50px 50px;
+  background-position: 0 0, 25px 25px;
+  animation: starfield 60s linear infinite;
+  opacity: 0.5;
+  z-index: -1;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes starfield {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-50px);
+  }
+}
+
+.hidden {
+  display: none !important;
 }
 
 .title {
@@ -25,23 +77,23 @@ body {
   margin-bottom: 2rem;
 }
 
-.btn-synth {
-  background: #000;
-  color: #ff2d90;
-  border: 4px solid #ff2d90;
+.btn {
+  background: #222;
+  color: #fff;
+  border: 4px solid #0ff;
   padding: 20px 30px;
   cursor: pointer;
   text-transform: uppercase;
-  box-shadow: 4px 4px #ff2d90;
+  box-shadow: 4px 4px #0ff;
 }
 
-.btn-synth.small {
+.btn.small {
   padding: 10px 15px;
   font-size: 0.8rem;
-  box-shadow: 3px 3px #ff2d90;
+  box-shadow: 3px 3px #0ff;
 }
 
-.btn-synth:active {
+.btn:active {
   box-shadow: none;
   transform: translate(4px, 4px);
 }
@@ -64,7 +116,7 @@ body {
 
 #top {
   font-size: 1.5rem;
-  color: #ff2d90;
+  color: #0ff;
 }
 
 .play-area {

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const game = new Game();
   game.init();
 
-  document.getElementById('startButton').addEventListener('click', () => game.start());
-  document.getElementById('resetButton').addEventListener('click', () => game.reset());
+  const menu = document.getElementById('menu');
+  const gameUI = document.getElementById('gameUI');
+
+  document.getElementById('startButton').addEventListener('click', () => {
+    menu.classList.add('hidden');
+    gameUI.classList.remove('hidden');
+    game.start();
+  });
+
+  document
+    .getElementById('resetButton')
+    .addEventListener('click', () => game.reset());
 });


### PR DESCRIPTION
## Summary
- revamp interface with retro start menu and hidden game HUD
- style UI in aggressive pink/black synthwave theme
- document new aesthetic features in README

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c7699150833087cbaeead6f5f1d1